### PR TITLE
fix benchmark test cases with b.Loop()

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -10,16 +10,15 @@ env:
   ENVIRONMENT: "production"
 
 jobs:
-  performance_regression_test:
-    name: Performance regression test
+  performance_regression_testing:
+    name: Performance regression testing
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.21.3' # The Go version to download (if necessary) and use.
- # Run benchmark with `go test -bench` and stores the output to a file
+          go-version: '^1.24.1' # The Go version to download (if necessary) and use.
       - name: Run benchmark
         run: go test -bench=. | tee output.txt
       - name: Analyze benchmark results with Nyrkiö
@@ -27,5 +26,4 @@ jobs:
         with:
           tool: 'go'
           output-file-path: output.txt
-          # Pick up your token at https://nyrkio.com/docs/getting-started
           nyrkio-token: ${{ secrets.NYRKIO_JWT_TOKEN }}

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module github.com/JayJamieson/striphtml
 
-go 1.21.3
+go 1.24.1
 
 require (
+	github.com/mattn/go-isatty v0.0.20
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.7.0
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf
@@ -11,7 +12,6 @@ require (
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.13.0 // indirect

--- a/striphtml_test.go
+++ b/striphtml_test.go
@@ -1069,8 +1069,10 @@ func BenchmarkFromString(b *testing.B) {
 			</table>
 		</body>
 	</html>`
-	_, err := FromString(inputHTML, Options{PrettyTables: true})
-	if err != nil {
-		panic(err)
+
+	for b.Loop() {
+		if _, err := FromString(inputHTML, Options{PrettyTables: true}); err != nil {
+			b.Error(err)
+		}
 	}
 }


### PR DESCRIPTION
Updates bench mark test case to use `b.Loop()` to correctly report benchmark results.

Updates github action with latest Go version